### PR TITLE
chore: fix minimatch GHSA-3ppc-4f35-3m26 advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"glob": "10.5.0"
+			"glob": "10.5.0",
+			"minimatch": "10.2.2"
 		},
 		"ignoredBuiltDependencies": [
 			"cypress"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   glob: 10.5.0
+  minimatch: 10.2.2
 
 importers:
 
@@ -908,11 +909,13 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.3:
+    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
+    engines: {node: 20 || >=22}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.2:
+    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.25.4:
     resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
@@ -1373,9 +1376,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@10.2.2:
+    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+    engines: {node: 18 || 20 || >=22}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -2597,11 +2600,11 @@ snapshots:
   asynckit@0.4.0:
     optional: true
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.3: {}
 
-  brace-expansion@2.0.2:
+  brace-expansion@5.0.2:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.3
 
   browserslist@4.25.4:
     dependencies:
@@ -2841,7 +2844,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 10.2.2
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -3081,9 +3084,9 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@9.0.5:
+  minimatch@10.2.2:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.2
 
   minipass@7.1.2: {}
 
@@ -3343,7 +3346,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.5.0
-      minimatch: 9.0.5
+      minimatch: 10.2.2
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary
- Address the new Dependabot alert for `minimatch` (`GHSA-3ppc-4f35-3m26`) by forcing a patched transitive version via pnpm overrides.
- Add `"minimatch": "10.2.2"` to `pnpm.overrides` in `package.json`.
- Regenerate `pnpm-lock.yaml` so vulnerable `minimatch@9.0.5` is replaced with `minimatch@10.2.2` across transitive paths (`glob` and `test-exclude`).

## Validation
- `pnpm audit --audit-level=high` ✅ no known vulnerabilities
- `TMPDIR=$HOME/tmp pnpm test:ci` ✅
- `TMPDIR=$HOME/tmp NODE_OPTIONS=\"--dns-result-order=ipv4first\" pnpm test:e2e:ci` ✅

## Note
- GitHub Dependabot alerts can take a short time to reprocess after merge; this branch contains the patched version required by the advisory (`>=10.2.1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version management to ensure consistency across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->